### PR TITLE
Allowing to store mocks on DB for multiple identifications

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.7.0
+
+Now you can store and retrieve mocks from the database according to the identifier, allowing you create multiple test scenario or data from multiple users using the sames endpoints. Also fixing import with .zip files.
+
 # 1.6.0
 
 Improvement to Database management

--- a/README.md
+++ b/README.md
@@ -215,6 +215,86 @@ Whenever a file is not found, either by a wrongly named @Mock or by an incorrect
 }
 ```
 
+# Record and Playback Mocks
+
+With this library you can also record API responses on a database and play it back if you want to map your API easily. 
+
+## Record Mocks
+
+To start recording your mock files, you need to just configure your Mock Interceptor as such:
+```
+//MockInterceptor setup
+config = MockConfig.Builder()
+  .saveMockMode(OptionRecordMock.RECORD)
+  .context { context } //mandatory
+  .build()
+```
+
+After this configuration, all the API calls will be stored in the database. If a duplicated call occurs, will be displayed a dialog asking if you want to replace the information or ignore. You can also set this on default on the MockInterceptor initialization. 
+
+```
+//MockInterceptor setup
+config = MockConfig.Builder()
+  .saveMockMode(OptionRecordMock.RECORD)
+  .replaceMockOption(ReplaceMockOption.DEFAULT | KEEP_MOCK | REPLACE_MOCK)
+  .context { context } //mandatory
+  .build()
+```
+
+You can also save the mock under some identification (for example, you have multiple users and you need to keep their mocks apart). You only need on run time, define witch identification you want to save the mocks.
+
+```
+MockInterceptor.setMockGroupIdentifier("The name of the group")
+```
+
+## Playback Mocks
+
+After saving all the mocks, you can playback them. You just need to change on the Mock Interceptor setup
+
+```
+//MockInterceptor setup
+config = MockConfig.Builder()
+  .saveMockMode(OptionRecordMock.PLAYBACK)
+  .context { context } //mandatory
+  .build()
+```
+
+and all api calls will be redirected to check if there is the information saved on the database. If you saved under some indentification, you just need to set the group identifier that you record. You can also get the list of group identifiers stored on the database with the function:
+
+> fun getAllMockIdentifiers() : List<String>
+
+## Export, Import, Replace and Delete Data
+
+You can control all the information saved on your database with those commands:
+
+**Export Database**
+The function will ask for READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE from de device, and export all data saved as a .db or a .zip containing all jsons stored.
+> fun exportDatabase()
+
+**Import Database**
+The function will ask for READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE from de device, and import a Json file, a .db file or a .zip file containing all .jsons files you want to import.
+> fun importDatabase()
+
+**Replace Database**
+The function will delete the current database and replace from the content of a .db file.
+> fun replaceDatabase()
+
+**Delete Database**
+The function will delete the current database.
+> fun deleteDatabase()
+
+You can also observe the database operation state with the MockInterceptor liveData. You just need to watch like:
+
+```
+MockInterceptor.databaseObserver.observe(this) { state ->
+    when (state) {
+        MockDatabaseState.LOADING -> TODO()
+        MockDatabaseState.SUCCESS -> TODO()
+        MockDatabaseState.ERROR -> TODO()
+    }
+}
+```
+
 That's all for now
 
 # Thanks

--- a/app/src/main/kotlin/com/gustafah/android/mockinterceptor/sample/ui/SampleActivity.kt
+++ b/app/src/main/kotlin/com/gustafah/android/mockinterceptor/sample/ui/SampleActivity.kt
@@ -7,12 +7,14 @@ import android.os.Bundle
 import android.view.View
 import android.widget.RadioButton
 import android.widget.RadioGroup
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import com.gustafah.android.mockinterceptor.MockConfig
 import com.gustafah.android.mockinterceptor.MockInterceptor
 import com.gustafah.android.mockinterceptor.notification.MockNotification
+import com.gustafah.android.mockinterceptor.persistence.MockDatabaseState
 import com.gustafah.android.mockinterceptor.sample.R
 import com.gustafah.android.mockinterceptor.sample.repository.SampleRepository
 import com.gustafah.android.mockinterceptor.sample.service.serviceClient
@@ -55,10 +57,13 @@ class SampleActivity : AppCompatActivity(R.layout.activity_sample) {
         setupMocksFromDatabase(viewModel, saveMockMode)
         setupMocksFromMockFile(viewModel)
 
+        MockInterceptor.databaseObserver.observe(this) {
+            Toast.makeText(this, it.name, Toast.LENGTH_SHORT).show()
+        }
         viewModel.responseLiveData.observe(this) {
+            cleanData()
             it.forEach { data ->
-                println(data.toJson())
-                text_response.append(data.toJson())
+                printData(data.toJson())
             }
         }
         viewModel.responseErrorLiveData.observe(this) {
@@ -135,6 +140,19 @@ class SampleActivity : AppCompatActivity(R.layout.activity_sample) {
         button_fetch_response.text =
             if (saveMockMode == MockConfig.OptionRecordMock.RECORD.ordinal) "Fetch Response from API"
             else "Fetch Response from Database"
+        button_set_identification.setOnClickListener {
+            layout_set_identification.isVisible = true
+        }
+        button_save_identification.setOnClickListener {
+            layout_set_identification.isVisible = false
+            MockInterceptor.setMockGroupIdentifier(edittext_set_identification.text.toString())
+        }
+        button_fetch_identifiers.setOnClickListener {
+            cleanData()
+            MockInterceptor.getAllMockIdentifiers().forEach { data ->
+                printData(data)
+            }
+        }
         button_fetch_response.setOnClickListener {
             viewModel.fetchResponseMock()
         }
@@ -212,6 +230,15 @@ class SampleActivity : AppCompatActivity(R.layout.activity_sample) {
             .create()
             .show()
 
+    }
+
+    private fun cleanData() {
+        text_response.text = ""
+    }
+
+    private fun printData(data: String) {
+        println(data)
+        text_response.append(data + "\n")
     }
 
 }

--- a/app/src/main/res/layout/activity_sample.xml
+++ b/app/src/main/res/layout/activity_sample.xml
@@ -67,6 +67,43 @@
                 tools:ignore="HardcodedText" />
 
             <Button
+                android:id="@+id/button_set_identification"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Set Identifications For Calls"
+                tools:ignore="HardcodedText" />
+
+            <androidx.appcompat.widget.LinearLayoutCompat
+                android:id="@+id/layout_set_identification"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                android:weightSum="3">
+
+                <EditText
+                    android:id="@+id/edittext_set_identification"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"/>
+
+                <Button
+                    android:id="@+id/button_save_identification"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Save"
+                    tools:ignore="HardcodedText"
+                    android:layout_weight="2"/>
+
+            </androidx.appcompat.widget.LinearLayoutCompat>
+
+            <Button
+                android:id="@+id/button_fetch_identifiers"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Get All Identifiers"
+                tools:ignore="HardcodedText" />
+
+            <Button
                 android:id="@+id/button_fetch_response"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Apr 01 18:22:58 BRT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/mock-interceptor/build.gradle
+++ b/mock-interceptor/build.gradle
@@ -14,6 +14,16 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+
+        kapt {
+            arguments {
+                arg("room.schemaLocation", "$projectDir/schemas".toString())
+            }
+        }
+    }
+
+    sourceSets {
+        androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
     }
 
     flavorDimensions "dim"
@@ -79,5 +89,6 @@ dependencies {
     implementation dependency_versions.coroutines
 
     api dependency_versions.room
+    api dependency_versions.roomktx
     kapt dependency_versions.roomProcessor
 }

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/MockConfig.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/MockConfig.kt
@@ -40,6 +40,7 @@ class MockConfig private constructor(builder: Builder) {
     val saveMockMode: OptionRecordMock
     val replaceMockOption: ReplaceMockOption
     val selectorMode: OptionsSelectorMode
+    var mockGroupIdentifier: String? = null
     val context: () -> Context
 
     private val processors: List<FileProcessor>

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/MockConfig.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/MockConfig.kt
@@ -55,6 +55,7 @@ class MockConfig private constructor(builder: Builder) {
         selectorMode = builder.selectorMode
         saveMockMode = builder.saveMockMode
         replaceMockOption = builder.replaceMockOption
+        mockGroupIdentifier = builder.mockGroupIdentifier
         delay = builder.delay ?: Range(0, 1)
         additionalMockFiles = builder.additionalMock
         context =
@@ -115,6 +116,8 @@ class MockConfig private constructor(builder: Builder) {
             private set
         internal var replaceMockOption: ReplaceMockOption = ReplaceMockOption.DEFAULT
             private set
+        internal var mockGroupIdentifier: String? = null
+            private set
         internal var context: (() -> Context)? = null
             private set
         internal var selectorMode: OptionsSelectorMode = OptionsSelectorMode.ALWAYS_ON_TOP
@@ -131,6 +134,7 @@ class MockConfig private constructor(builder: Builder) {
         fun selectorMode(mode: OptionsSelectorMode) = apply { this.selectorMode = mode }
         fun saveMockMode(saveMock: OptionRecordMock) = apply { this.saveMockMode = saveMock }
         fun replaceMockOption(replaceMockOption: ReplaceMockOption) = apply { this.replaceMockOption = replaceMockOption }
+        fun setMockGroupIdentifier(mockGroupIdentifier: String) = apply { this.mockGroupIdentifier = mockGroupIdentifier }
         fun setDelay(minDelay: Int, maxDelay: Int) = setDelay(Range(minDelay, maxDelay))
         fun setDelay(delay: Range<Int>) = apply { this.delay = delay }
         fun additionalMocks(additionalMockFiles: List<String>) =

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/MockDatabaseUtils.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/MockDatabaseUtils.kt
@@ -1,0 +1,259 @@
+package com.gustafah.android.mockinterceptor
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.widget.Toast
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.gustafah.android.mockinterceptor.MockFileUtils.DIRECTORY_NAME
+import com.gustafah.android.mockinterceptor.persistence.MockDatabaseState
+import com.gustafah.android.mockinterceptor.persistence.MockInterceptorDatabase
+import com.gustafah.android.mockinterceptor.persistence.entities.MockEntity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.FileReader
+import java.io.IOException
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+
+object MockDatabaseUtils {
+
+    private val job = Job()
+    private val scope = CoroutineScope(Dispatchers.IO + job)
+
+    internal val databaseObserver: MutableLiveData<MockDatabaseState> = MutableLiveData()
+
+    internal fun exportDatabaseInDBFile() {
+        val context = MockInterceptor.config.context()
+        val database = context.getDatabasePath(MockInterceptorDatabase.NAME)
+        if (database.exists()) {
+            MockUtils.shareFile(context, database)
+        } else {
+            MockUtils.createDialog(
+                context,
+                context.getString(R.string.mock_delete_database_error),
+                context.getString(R.string.mock_alert_button_ok)
+            )
+        }
+    }
+
+    internal fun exportDatabaseInJsonFiles() {
+        val context = MockInterceptor.config.context()
+
+        scope.launch {
+            try {
+                updateObserver(MockDatabaseState.LOADING)
+                val directory = File(context.getExternalFilesDir(null), DIRECTORY_NAME)
+                val allMocks = MockInterceptorDatabase.getInstance(context).mockDao().getAllMocks()
+                allMocks?.forEach { MockFileUtils.writeToFile(directory, it.id, it.fileName, it.fileData, context) }
+                zipFileAtPath(
+                    directory.path,
+                    context.filesDir.path + MockFileUtils.FILE_EXTENSION_ZIP
+                )
+                if (directory.exists()) MockFileUtils.deleteRecursive(directory)
+                updateObserver(MockDatabaseState.SUCCESS)
+                MockUtils.shareFile(
+                    context,
+                    File(context.filesDir.path + MockFileUtils.FILE_EXTENSION_ZIP)
+                )
+            } catch (ex: Exception) {
+                updateObserver(MockDatabaseState.ERROR)
+            }
+        }
+    }
+
+    internal fun recreateDatabase(uri: Uri, contentResolver: ContentResolver) =
+        scope.launch(Dispatchers.IO) {
+            try {
+                updateObserver(MockDatabaseState.LOADING)
+                val context = MockInterceptor.config.context()
+                val file = File(
+                    MockFileUtils.writeFileContent(
+                        uri,
+                        context.getExternalFilesDir(null),
+                        contentResolver
+                    ) ?: ""
+                )
+                when (file.path.substring(file.path.lastIndexOf("."))) {
+                    MockFileUtils.FILE_EXTENSION_DB -> importDatabaseInCleanMode(file, context)
+                    MockFileUtils.FILE_EXTENSION_JSON -> addJsonToDatabase(context, MockInterceptor.config.mockGroupIdentifier ?: "", file)
+                    MockFileUtils.FILE_EXTENSION_ZIP -> importZipToDatabase(context, file)
+                    else -> throw IllegalAccessError("")
+                }
+                updateObserver(MockDatabaseState.SUCCESS)
+            } catch (ex: Exception) {
+                updateObserver(MockDatabaseState.ERROR)
+            }
+        }
+
+    internal fun replaceDatabase(uri: Uri, contentResolver: ContentResolver) =
+        scope.launch(Dispatchers.IO) {
+            try {
+                updateObserver(MockDatabaseState.LOADING)
+                val context = MockInterceptor.config.context()
+                val file = File(
+                    MockFileUtils.writeFileContent(
+                        uri,
+                        context.getExternalFilesDir(null),
+                        contentResolver
+                    ) ?: ""
+                )
+                importDatabaseReplacing(file, context)
+                updateObserver(MockDatabaseState.SUCCESS)
+            } catch (ex: Exception) {
+                updateObserver(MockDatabaseState.ERROR)
+            }
+        }
+
+    internal fun deleteAllDatabase() =
+        scope.launch {
+            val context = MockInterceptor.config.context()
+            kotlin.runCatching {
+                MockInterceptorDatabase.getInstance(context).clearAllTables()
+                val database = context.getDatabasePath(MockInterceptorDatabase.NAME)
+                if (database.exists()) database.delete()
+            }
+        }
+
+    private suspend fun updateObserver(data: MockDatabaseState) {
+        withContext(Dispatchers.Main) {
+            databaseObserver.value = data
+        }
+    }
+
+    private fun importDatabaseInCleanMode(file: File, context: Context) {
+        deleteAllDatabase()
+        MockInterceptorDatabase.getInstance(context, file)
+    }
+
+    private fun importDatabaseReplacing(file: File, context: Context) {
+        val database = context.getDatabasePath(MockInterceptorDatabase.NAME)
+        MockFileUtils.copy(file, database)
+    }
+
+    private fun addJsonToDatabase(context: Context, identifier: String, json: File) {
+        val br = BufferedReader(FileReader(json))
+        var line: String?
+        val data = StringBuilder()
+
+        while (br.readLine().also { line = it } != null) {
+            data.append(line)
+            data.append('\n')
+        }
+        br.close()
+        MockInterceptorDatabase.getInstance(context).mockDao().insertMock(
+            MockEntity(identifier, json.name, data.toString())
+        )
+    }
+
+    private fun importZipToDatabase(context: Context, file: File) {
+        val directory = File(context.filesDir.parentFile.path + "/" + DIRECTORY_NAME)
+        if (!directory.exists()) directory.mkdirs()
+        unzipFileAtPath(file, directory)
+        loadFilesToDatabase(context, "", directory)
+        if (directory.exists()) MockFileUtils.deleteRecursive(directory)
+    }
+
+    private fun loadFilesToDatabase(context: Context, id: String, dir: File) {
+        dir.listFiles()?.forEach { file ->
+            val fileName = if (file.name == DIRECTORY_NAME) "" else file.name
+            if (file.isDirectory) loadFilesToDatabase(context, fileName, file)
+            else addJsonToDatabase(context, id, file)
+        }
+    }
+
+    private fun unzipFileAtPath(zipFile: File?, targetDirectory: File?) {
+        ZipInputStream(BufferedInputStream(FileInputStream(zipFile))).use { zis ->
+            var count: Int
+            val buffer = ByteArray(8192)
+            while (true) {
+                val ze = zis.nextEntry ?: break
+                val file = File(targetDirectory, ze.name)
+                val dir = if (ze.isDirectory) file else file.parentFile
+                if (!dir.isDirectory && !dir.mkdirs()) throw FileNotFoundException(
+                    "Failed to ensure directory: " +
+                            dir.absolutePath
+                )
+                if (ze.isDirectory) continue
+                FileOutputStream(file).use { fout ->
+                    while (zis.read(buffer).also { count = it } != -1) fout.write(buffer, 0, count)
+                }
+            }
+        }
+    }
+
+    private fun zipFileAtPath(sourcePath: String, toLocation: String?): Boolean {
+        val BUFFER = 2048
+        val sourceFile = File(sourcePath)
+        try {
+            val dest = FileOutputStream(toLocation)
+            val out = ZipOutputStream(
+                BufferedOutputStream(dest)
+            )
+            if (sourceFile.isDirectory) {
+                zipSubFolder(out, sourceFile, sourceFile.parent?.length ?: 0)
+            } else {
+                val data = ByteArray(BUFFER)
+                val fi = FileInputStream(sourcePath)
+                val origin = BufferedInputStream(fi, BUFFER)
+                val entry = ZipEntry(MockFileUtils.getLastPathComponent(sourcePath))
+                entry.time = sourceFile.lastModified()
+                out.putNextEntry(entry)
+                var count: Int
+                while (origin.read(data, 0, BUFFER).also { count = it } != -1) {
+                    out.write(data, 0, count)
+                }
+            }
+            out.close()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return false
+        }
+        return true
+    }
+
+    @Throws(IOException::class)
+    private fun zipSubFolder(
+        out: ZipOutputStream, folder: File,
+        basePathLength: Int
+    ) {
+        val BUFFER = 2048
+        val fileList = folder.listFiles()
+        var origin: BufferedInputStream?
+        fileList?.forEach { file ->
+            if (file.isDirectory) {
+                zipSubFolder(out, file, basePathLength)
+            } else {
+                val data = ByteArray(BUFFER)
+                val unmodifiedFilePath = file.path
+                val relativePath = unmodifiedFilePath.substring(basePathLength)
+                val fi = FileInputStream(unmodifiedFilePath)
+                origin = BufferedInputStream(fi, BUFFER)
+                val entry = ZipEntry(relativePath)
+                entry.time = file.lastModified()
+                out.putNextEntry(entry)
+                var count = 0
+                while (origin?.read(data, 0, BUFFER).also { value ->
+                        value?.let { count = value }
+                    } != -1) {
+                    out.write(data, 0, count)
+                }
+                origin?.close()
+            }
+        }
+    }
+
+
+}

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/MockFileUtils.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/MockFileUtils.kt
@@ -6,27 +6,18 @@ import android.net.Uri
 import android.provider.OpenableColumns
 import android.util.Log
 import com.gustafah.android.mockinterceptor.MockUtils.ERROR_WRITING_FILE
-import com.gustafah.android.mockinterceptor.persistence.MockInterceptorDatabase
-import com.gustafah.android.mockinterceptor.persistence.entities.MockEntity
 import okhttp3.Request
-import java.io.BufferedInputStream
-import java.io.BufferedOutputStream
-import java.io.BufferedReader
 import java.io.File
 import java.io.FileInputStream
-import java.io.FileNotFoundException
 import java.io.FileOutputStream
-import java.io.FileReader
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.io.OutputStreamWriter
-import java.util.zip.ZipEntry
-import java.util.zip.ZipInputStream
-import java.util.zip.ZipOutputStream
 
 object MockFileUtils {
 
+    const val DIRECTORY_NAME = "mock_files"
     const val FILE_EXTENSION_JSON = ".json"
     const val FILE_EXTENSION_ZIP = ".zip"
     const val FILE_EXTENSION_DB = ".db"
@@ -87,12 +78,23 @@ object MockFileUtils {
         return displayName
     }
 
-    internal fun writeToFile(fileName: String, data: String, context: Context) {
+    internal fun writeToFile(directory: File, id: String, fileName: String, data: String, context: Context) {
         try {
-            val outputStreamWriter =
-                OutputStreamWriter(context.openFileOutput(fileName, Context.MODE_PRIVATE))
+            if (!directory.exists()) directory.mkdirs()
+            val subDirectory = if (id != "") {
+                val file = File(directory, id)
+                if (!file.exists()) file.mkdirs()
+                file
+            } else directory
+            val file = File(subDirectory, fileName)
+
+            val outputStream = FileOutputStream(file)
+            val outputStreamWriter = OutputStreamWriter(outputStream)
+
             outputStreamWriter.write(data)
+
             outputStreamWriter.close()
+            outputStream.close()
         } catch (e: IOException) {
             Log.e(MockUtils::class.simpleName, e.message ?: ERROR_WRITING_FILE)
         }
@@ -105,105 +107,8 @@ object MockFileUtils {
         fileOrDirectory.delete()
     }
 
-    internal fun addJsonToDatabase(context: Context, json: File) {
-        val br = BufferedReader(FileReader(json))
-        var line: String?
-        val data = StringBuilder()
-
-        while (br.readLine().also { line = it } != null) {
-            data.append(line)
-            data.append('\n')
-        }
-        br.close()
-        MockInterceptorDatabase.getInstance(context).mockDao().insertMock(
-            MockEntity(json.name, data.toString())
-        )
-    }
-
-    fun zipFileAtPath(sourcePath: String, toLocation: String?): Boolean {
-        val BUFFER = 2048
-        val sourceFile = File(sourcePath)
-        try {
-            val dest = FileOutputStream(toLocation)
-            val out = ZipOutputStream(
-                BufferedOutputStream(dest)
-            )
-            if (sourceFile.isDirectory) {
-                zipSubFolder(out, sourceFile, sourceFile.parent?.length ?: 0)
-            } else {
-                val data = ByteArray(BUFFER)
-                val fi = FileInputStream(sourcePath)
-                val origin = BufferedInputStream(fi, BUFFER)
-                val entry = ZipEntry(getLastPathComponent(sourcePath))
-                entry.time = sourceFile.lastModified()
-                out.putNextEntry(entry)
-                var count: Int
-                while (origin.read(data, 0, BUFFER).also { count = it } != -1) {
-                    out.write(data, 0, count)
-                }
-            }
-            out.close()
-        } catch (e: Exception) {
-            e.printStackTrace()
-            return false
-        }
-        return true
-    }
-
-    @Throws(IOException::class)
-    private fun zipSubFolder(
-        out: ZipOutputStream, folder: File,
-        basePathLength: Int
-    ) {
-        val BUFFER = 2048
-        val fileList = folder.listFiles()
-        var origin: BufferedInputStream?
-        fileList?.forEach { file ->
-            if (file.isDirectory) {
-                zipSubFolder(out, file, basePathLength)
-            } else {
-                val data = ByteArray(BUFFER)
-                val unmodifiedFilePath = file.path
-                val relativePath = unmodifiedFilePath.substring(basePathLength)
-                val fi = FileInputStream(unmodifiedFilePath)
-                origin = BufferedInputStream(fi, BUFFER)
-                val entry = ZipEntry(relativePath)
-                entry.time = file.lastModified()
-                out.putNextEntry(entry)
-                var count = 0
-                while (origin?.read(data, 0, BUFFER).also { value ->
-                        value?.let { count = value }
-                    } != -1) {
-                    out.write(data, 0, count)
-                }
-                origin?.close()
-            }
-        }
-    }
-
-    private fun getLastPathComponent(filePath: String): String {
+    internal fun getLastPathComponent(filePath: String): String {
         val segments = filePath.split("/").toTypedArray()
         return if (segments.isEmpty()) "" else segments[segments.size - 1]
     }
-
-    fun unzipFileAtPath(zipFile: File?, targetDirectory: File?) {
-        ZipInputStream(BufferedInputStream(FileInputStream(zipFile))).use { zis ->
-            var count: Int
-            val buffer = ByteArray(8192)
-            while (true) {
-                val ze = zis.nextEntry ?: break
-                val file = File(targetDirectory, ze.name)
-                val dir = if (ze.isDirectory) file else file.parentFile
-                if (!dir.isDirectory && !dir.mkdirs()) throw FileNotFoundException(
-                    "Failed to ensure directory: " +
-                            dir.absolutePath
-                )
-                if (ze.isDirectory) continue
-                FileOutputStream(file).use { fout ->
-                    while (zis.read(buffer).also { count = it } != -1) fout.write(buffer, 0, count)
-                }
-            }
-        }
-    }
-
 }

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/persistence/MockDatabaseState.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/persistence/MockDatabaseState.kt
@@ -1,0 +1,7 @@
+package com.gustafah.android.mockinterceptor.persistence
+
+enum class MockDatabaseState {
+    LOADING,
+    SUCCESS,
+    ERROR
+}

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/persistence/MockInterceptorDatabase.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/persistence/MockInterceptorDatabase.kt
@@ -1,6 +1,7 @@
 package com.gustafah.android.mockinterceptor.persistence
 
 import android.content.Context
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -11,13 +12,16 @@ import java.io.File
 @Database(
     version = MockInterceptorDatabase.VERSION,
     exportSchema = true,
-    entities = [MockEntity::class]
+    entities = [MockEntity::class],
+    autoMigrations = [
+        AutoMigration(from = 1, to = MockInterceptorDatabase.VERSION)
+    ]
 )
 internal abstract class MockInterceptorDatabase : RoomDatabase() {
 
     companion object {
         const val NAME = "mock-interceptor.db"
-        const val VERSION = 1
+        const val VERSION = 2
 
         private var instance: MockInterceptorDatabase? = null
 

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/persistence/dao/MockDao.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/persistence/dao/MockDao.kt
@@ -12,8 +12,11 @@ interface MockDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertMock(mockEntity: MockEntity)
 
-    @Query("SELECT * FROM mockentity WHERE file_name = :fileName")
-    fun findMock(fileName: String) : MockEntity?
+    @Query("SELECT * FROM mockentity WHERE file_name = :fileName AND id = :id")
+    fun findMock(id: String, fileName: String) : MockEntity?
+
+    @Query("SELECT (id) FROM mockentity")
+    suspend fun getAllIdentifiers() : List<String>
 
     @Query("SELECT * FROM mockentity")
     fun getAllMocks() : List<MockEntity>?

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/persistence/entities/MockEntity.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/persistence/entities/MockEntity.kt
@@ -4,9 +4,10 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-@Entity
+@Entity(primaryKeys = ["id", "file_name"])
 data class MockEntity(
-    @PrimaryKey
+    @ColumnInfo(name = "id", defaultValue = "")
+    val id: String,
     @ColumnInfo(name = "file_name")
     val fileName: String,
     @ColumnInfo(name = "file_data")

--- a/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/ui/MockImportDatabaseActivity.kt
+++ b/mock-interceptor/src/client/kotlin/com/gustafah/android/mockinterceptor/ui/MockImportDatabaseActivity.kt
@@ -4,11 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.appcompat.app.AppCompatActivity
-import com.gustafah.android.mockinterceptor.MockInterceptor
-import com.gustafah.android.mockinterceptor.MockFileUtils.writeFileContent
+import com.gustafah.android.mockinterceptor.MockDatabaseUtils
 import com.gustafah.android.mockinterceptor.MockUtils.ERROR_FILE_NOT_FOUND
 import com.gustafah.android.mockinterceptor.R
-import java.io.File
 
 internal const val IMPORT_DATABASE_MODE = "import_database_mode"
 internal const val UPDATE_INFO = 3455
@@ -33,10 +31,10 @@ class MockImportDatabaseActivity : AppCompatActivity() {
                 val info = data.data!!
                 when (requestCode) {
                     CLEAR_DATABASE -> {
-                        MockInterceptor.replaceDatabase(info, contentResolver)
+                        MockDatabaseUtils.replaceDatabase(info, contentResolver)
                     }
                     else -> {
-                        MockInterceptor.recreateDatabase(info, contentResolver)
+                        MockDatabaseUtils.recreateDatabase(info, contentResolver)
                     }
                 }
             } else {

--- a/versions.gradle
+++ b/versions.gradle
@@ -16,6 +16,7 @@ ext.dependency_versions = [
         retrofitConverter  : 'com.squareup.retrofit2:converter-gson:2.3.0',
         threetenbp         : 'org.threeten:threetenbp:1.4.0:no-tzdb',
 
-        room               : 'androidx.room:room-runtime:2.3.0',
-        roomProcessor      : 'androidx.room:room-compiler:2.3.0'
+        room               : 'androidx.room:room-runtime:2.4.3',
+        roomktx           : 'androidx.room:room-ktx:2.4.3',
+        roomProcessor      : 'androidx.room:room-compiler:2.4.3'
 ]


### PR DESCRIPTION
Now you can store and retrieve mocks from the database according to the identifier, allowing you create multiple test scenario or data from multiple users using the sames endpoints. Also fixing import with .zip files.
